### PR TITLE
chore: Add conventional-commit linting for PR titles

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,13 @@
+name: Checks
+on:
+  pull_request:
+    types: ["opened", "edited", "reopened", "synchronize"]
+jobs:
+  verify-pr:
+    name: Verify the PR standards
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jef/conventional-commits-pr-action@v1
+        with:
+          comment: true
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The PR enables conventional-commit linting on the PR titles. The PR linting in combination with Squash & Merge will force the commits landing into master to follow the conventional commits guidelines. Based on these guidelines a release procedure might get automated. 

There's currently one edge-case where a non-conventional commit might slip into the main branch. If the PR only contains one commit, when squashing and the squashed commit will assume the commits title and NOT the PR's title, which is highly unfortunate. 

However,  think that's a trade-off we have to make if we don't want to enforce linting for every commit message.